### PR TITLE
Handle distinct error conditions uniquely

### DIFF
--- a/output/client.go
+++ b/output/client.go
@@ -164,8 +164,12 @@ func (logzioClient *LogzioClient) doRequest(req *http.Request) int {
 	defer resp.Body.Close()
 
 	_, err = ioutil.ReadAll(resp.Body)
-	if err != nil || resp.StatusCode < 200 || resp.StatusCode > 299 {
-		logzioClient.logger.Log(fmt.Sprintf("recieved an error from logz.io listener: %+v", err))
+	if err != nil {
+		logzioClient.logger.Log(fmt.Sprintf("recieved an error attempting to read from logz.io listener: %+v", err))
+		return resp.StatusCode
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		logzioClient.logger.Log(fmt.Sprintf("recieved a non-200 HTTP status code from logz.io listener: %d", resp.StatusCode))
 		return resp.StatusCode
 	}
 	logzioClient.logger.Debug("successfully sent bulk to logz.io\n")

--- a/output/client.go
+++ b/output/client.go
@@ -163,13 +163,13 @@ func (logzioClient *LogzioClient) doRequest(req *http.Request) int {
 	}
 	defer resp.Body.Close()
 
-	_, err = ioutil.ReadAll(resp.Body)
+	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		logzioClient.logger.Log(fmt.Sprintf("recieved an error attempting to read from logz.io listener: %+v", err))
 		return resp.StatusCode
 	}
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		logzioClient.logger.Log(fmt.Sprintf("recieved a non-200 HTTP status code from logz.io listener: %d", resp.StatusCode))
+		logzioClient.logger.Log(fmt.Sprintf("recieved a non-2xx HTTP status code from logz.io listener: %d (%v)", resp.StatusCode, body))
 		return resp.StatusCode
 	}
 	logzioClient.logger.Debug("successfully sent bulk to logz.io\n")

--- a/output/client.go
+++ b/output/client.go
@@ -169,7 +169,7 @@ func (logzioClient *LogzioClient) doRequest(req *http.Request) int {
 		return resp.StatusCode
 	}
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		logzioClient.logger.Log(fmt.Sprintf("recieved a non-2xx HTTP status code from logz.io listener: %d (%v)", resp.StatusCode, body))
+		logzioClient.logger.Log(fmt.Sprintf("recieved a non-2xx HTTP status code from logz.io listener: %d (%v)", resp.StatusCode, string(body)))
 		return resp.StatusCode
 	}
 	logzioClient.logger.Debug("successfully sent bulk to logz.io\n")

--- a/output/client.go
+++ b/output/client.go
@@ -165,11 +165,11 @@ func (logzioClient *LogzioClient) doRequest(req *http.Request) int {
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		logzioClient.logger.Log(fmt.Sprintf("recieved an error attempting to read from logz.io listener: %+v", err))
+		logzioClient.logger.Log(fmt.Sprintf("received an error attempting to read from logz.io listener: %+v", err))
 		return resp.StatusCode
 	}
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		logzioClient.logger.Log(fmt.Sprintf("recieved a non-2xx HTTP status code from logz.io listener: %d (%v)", resp.StatusCode, string(body)))
+		logzioClient.logger.Log(fmt.Sprintf("received a non-2xx HTTP status code from logz.io listener: %d (%v)", resp.StatusCode, string(body)))
 		return resp.StatusCode
 	}
 	logzioClient.logger.Debug("successfully sent bulk to logz.io\n")


### PR DESCRIPTION
Lines like this in the error output are not so useful:

```
2020/08/24 02:20:35 [logzio] recieved an error from logz.io listener: <nil>
2020/08/24 02:20:39 [logzio] recieved an error from logz.io listener: <nil>
```