### PR TITLE
Update fluent-bit version to 1.5.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# direnv
+.envrc

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /go/src/logzio
 RUN dep ensure -v \
     && make all
 
-FROM fluent/fluent-bit:1.1
+FROM fluent/fluent-bit:1.5.4
 
 COPY --from=gobuilder /go/src/logzio/build/out_logzio.so /fluent-bit/bin/
 COPY --from=gobuilder /go/src/logzio/test/fluent-bit.conf /fluent-bit/etc/


### PR DESCRIPTION
The logzio/fluent-bit-output image on DockerHub is building off fluent-bit 1.1.

The latest version of fluent-bit is 1.5.4. This PR is updating the Dockerfile to use the latest version. Once this is approved and merged, do y'all mind pushing up the latest image to DokerHub?

----

I have tested this change and logs are coming through to my logz.io account. I am also using one of the features from [fluent-bit 1.5.1 where you can have multiple path patterns separated by commas](https://fluentbit.io/announcements/v1.5.1/) so things are definitely working as expected.

My test image: https://hub.docker.com/repository/docker/alysivji/logzio-bit-test (tag is 1.5.4)