### PR TITLE
Retry when Do returns an error

### DIFF
--- a/output/client.go
+++ b/output/client.go
@@ -161,8 +161,8 @@ func (logzioClient *LogzioClient) createRequest() (*http.Request, int) {
 func (logzioClient *LogzioClient) doRequest(req *http.Request) int {
 	resp, err := logzioClient.client.Do(req)
 	if err != nil {
-		logzioClient.logger.Log(fmt.Sprintf("failed to do client request: %+v", err))
-		return output.FLB_ERROR
+		logzioClient.logger.Log(fmt.Sprintf("failed to do retryable client request: %+v", err))
+		return output.FLB_RETRY
 	}
 	defer resp.Body.Close()
 
@@ -181,7 +181,7 @@ func (logzioClient *LogzioClient) doRequest(req *http.Request) int {
 
 func (logzioClient *LogzioClient) shouldRetry(code int) int {
 	logzioClient.logger.Debug(fmt.Sprintf("response error code: %d", code))
-	if code >= 500 {
+	if code >= 500 || code == output.FLB_RETRY {
 		return output.FLB_RETRY
 	}
 	return output.FLB_ERROR


### PR DESCRIPTION
With this change, When sendBulk() is called, doRequest() will return output.FLB_RETRY when there are transient errors or temporary server-side errors.  sendBulk() will then call shouldRetry() which then properly returns output.FLB_RETRY.

Without this change, transient connection errors can cause dropped events.

Per https://pkg.go.dev/net/http, "an error is returned if caused by client policy (such as CheckRedirect), or failure to speak HTTP (such as a network connectivity problem)."