### PR TITLE
ci: pin softprops/action-gh-release to a commit SHA

### DIFF
--- a/.github/workflows/auto-generate-binary.yaml
+++ b/.github/workflows/auto-generate-binary.yaml
@@ -137,7 +137,7 @@ jobs:
         run: find artifacts -type f
 
       - name: Upload Binaries to Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: ${{ github.event.release.tag_name }}
           files: |


### PR DESCRIPTION
`auto-generate-binary.yaml` pins `softprops/action-gh-release` to `3bb1273`, the commit `v2` currently points at. A tag can be repointed by whoever controls the upstream repository; a SHA cannot. No version change and no behaviour change. This step publishes release binaries, so it runs with write access to releases.

Note that #58 proposes bumping this action from 2 to 3. If that is taken, the reference will need re-pinning at the v3 commit rather than reverting to a bare tag.